### PR TITLE
Update to React 16

### DIFF
--- a/__tests__/getDocAsJSON-test.js
+++ b/__tests__/getDocAsJSON-test.js
@@ -33,15 +33,14 @@ DeprecatedComponent.propTypes = {
   testDeprecated: ReactPropTypes.string,
 };
 const NoPropTypeComponent = () => <div>fake</div>;
-/* eslint-disable react/prefer-es6-class, react/prefer-stateless-function */
-const ExtraInfoComponent = React.createClass({
+
+class ExtraInfoComponent {
   render() {
     return (
       <div>fake</div>
     );
-  },
-});
-/* eslint-enable react/prefer-es6-class, react/prefer-stateless-function */
+  }
+}
 
 schema(DocumentedComponent, {
   description: 'component',

--- a/__tests__/getDocAsMarkdown-test.js
+++ b/__tests__/getDocAsMarkdown-test.js
@@ -33,15 +33,14 @@ DeprecatedComponent.propTypes = {
   testDeprecated: ReactPropTypes.string,
 };
 const NoPropTypeComponent = () => <div>fake</div>;
-/* eslint-disable react/prefer-es6-class, react/prefer-stateless-function */
-const ExtraInfoComponent = React.createClass({
+
+class ExtraInfoComponent {
   render() {
     return (
       <div>fake</div>
     );
-  },
-});
-/* eslint-enable react/prefer-es6-class, react/prefer-stateless-function */
+  }
+}
 
 schema(DocumentedComponent, {
   description: 'component',

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "type": "git",
     "url": "https://github.com/grommet/react-desc.git"
   },
-  "dependencies": {
-    "prop-types": "^15.5.8",
-    "react": "^15.5.4"
+  "peerDependencies": {
+    "react": ">= 15.x || > 16.x",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel-cli": "^6.5.2",
@@ -30,7 +30,9 @@
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.4.1",
-    "jest": "^16.0.1"
+    "jest": "^16.0.1",
+    "prop-types": "^15.5.8",
+    "react": "16.0.0"
   },
   "scripts": {
     "build": "npm run test && npm run lint && npm run compile",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/grommet/react-desc.git"
   },
   "peerDependencies": {
-    "react": ">= 15.x || > 16.x",
+    "react": ">= 15.5.4 < 16 || 16.x",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Also shift react and prop-types into peerDependencies so that it doesn't interfere with upstream package's React version.