### PR TITLE
Make optional shape properties not required

### DIFF
--- a/__tests__/__snapshots__/describe-test.js.snap
+++ b/__tests__/__snapshots__/describe-test.js.snap
@@ -478,7 +478,7 @@ Object {
     },
     Object {
       "description": "shape",
-      "format": "{color: string,fontSize: number,one: string | number | any | any,test: any,test2: {test3: string,test4: {test5: string,test6: number,test7: any,test8: string[]}},test9: \\"type1\\" | \\"type2\\" | {type: \\"type1\\" | \\"type2\\",count: number} | \\"type1\\" | \\"type2\\" | {type: \\"type1\\" | \\"type2\\",count: number}[]}",
+      "format": "{color?: string,fontSize?: number,one?: string | number | any | any,test?: any,test2?: {test3: string,test4?: {test5?: string,test6?: number,test7?: any,test8?: string[]}},test9?: \\"type1\\" | \\"type2\\" | {type?: \\"type1\\" | \\"type2\\",count?: number} | \\"type1\\" | \\"type2\\" | {type?: \\"type1\\" | \\"type2\\",count?: number}[]}",
       "name": "test16",
     },
     Object {
@@ -949,7 +949,7 @@ Object {
     },
     Object {
       "description": "shape",
-      "format": "{color: string,fontSize: number,one: string | number | any | any,test: any,test2: {test3: string,test4: {test5: string,test6: number,test7: any,test8: string[]}},test9: \\"type1\\" | \\"type2\\" | {type: \\"type1\\" | \\"type2\\",count: number} | \\"type1\\" | \\"type2\\" | {type: \\"type1\\" | \\"type2\\",count: number}[]}",
+      "format": "{color?: string,fontSize?: number,one?: string | number | any | any,test?: any,test2?: {test3: string,test4?: {test5?: string,test6?: number,test7?: any,test8?: string[]}},test9?: \\"type1\\" | \\"type2\\" | {type?: \\"type1\\" | \\"type2\\",count?: number} | \\"type1\\" | \\"type2\\" | {type?: \\"type1\\" | \\"type2\\",count?: number}[]}",
       "name": "test16",
     },
     Object {

--- a/src/descToTypescript.js
+++ b/src/descToTypescript.js
@@ -15,7 +15,7 @@ const shapeFormat = (shape) => {
     } else {
       valueFormat = propTypeFormat(value);
     }
-    return `${key}: ${valueFormat}`;
+    return `${key}${value.reactDesc && value.reactDesc.required ? '' : '?'}: ${valueFormat}`;
   });
   return `{${props.join(',')}}`;
 };


### PR DESCRIPTION
This should help with https://github.com/grommet/grommet/issues/2464

I am not sure if i should also change the total behaviour on required properties. seems not handled at the moment and at least in grommet it is handled directly in the generation script.