### PR TITLE
Add capability to specify component intrinsic element

### DIFF
--- a/__tests__/__snapshots__/describe-test.js.snap
+++ b/__tests__/__snapshots__/describe-test.js.snap
@@ -513,6 +513,7 @@ Object {
   ],
   "description": "component",
   "details": "component details",
+  "intrinsicElement": "label",
   "name": "Component",
   "properties": Array [
     Object {
@@ -853,7 +854,12 @@ testDeprecated Defaults to \`abc\`.
 \`\`\`
 string
 \`\`\`
-  "
+  
+## Intrinsic element
+
+\`\`\`
+label
+\`\`\`"
 `;
 
 exports[`returns a documented typescript 1`] = `
@@ -870,6 +876,7 @@ Object {
   ],
   "description": "component",
   "details": "component details",
+  "intrinsicElement": "label",
   "name": "Component",
   "properties": Array [
     Object {

--- a/__tests__/describe-test.js
+++ b/__tests__/describe-test.js
@@ -57,7 +57,8 @@ const DocumentedComponent = describe(Component)
   ])
   .description('component')
   .details('component details')
-  .usage('test');
+  .usage('test')
+  .intrinsicElement('label');
 const DeprecatedComponent = describe(() => {})
   .deprecated('yes it is deprecated')
   .availableAt([

--- a/src/descToMarkdown.js
+++ b/src/descToMarkdown.js
@@ -61,6 +61,17 @@ ${props.join('\n')}
   `;
 }
 
+function getIntrinsicElement({ intrinsicElement }) {
+  return intrinsicElement ? (
+    `
+## Intrinsic element
+
+${code}
+${intrinsicElement}
+${code}`
+  ) : '';
+}
+
 export default function descToMarkdown(component, reactDesc) {
   if (!component) {
     throw new Error('react-desc: component is required');
@@ -71,5 +82,6 @@ export default function descToMarkdown(component, reactDesc) {
   const header = getHeader(documentation);
   const usage = getUsage(documentation);
   const properties = getProperties(documentation);
-  return `${header}${availableAt}${usage}${properties}`;
+  const intrinsicElement = getIntrinsicElement(documentation);
+  return `${header}${availableAt}${usage}${properties}${intrinsicElement}`;
 }

--- a/src/describe.js
+++ b/src/describe.js
@@ -62,6 +62,7 @@ export default function describe(ComponentInstance) {
   DocumentedComponent.details = addDocumentationProp('details');
   DocumentedComponent.deprecated = addDocumentationProp('deprecated');
   DocumentedComponent.usage = addDocumentationProp('usage');
+  DocumentedComponent.intrinsicElement = addDocumentationProp('intrinsicElement');
 
   DocumentedComponent.toJSON = descToJSON.bind(null, ComponentInstance, documentation);
   DocumentedComponent.toTypescript = descToTypescript.bind(null, ComponentInstance, documentation);


### PR DESCRIPTION
I think this should help tackling some typescript issues mainly https://github.com/grommet/grommet/issues/2325 , with the idea being to allow specify something similar 
`declare const TextInput: React.ComponentType<TextInputProps & JSX.IntrinsicElements['input']>;`