### PR TITLE
Wrap function definition

### DIFF
--- a/__tests__/__snapshots__/describe-test.js.snap
+++ b/__tests__/__snapshots__/describe-test.js.snap
@@ -433,7 +433,7 @@ Object {
     },
     Object {
       "description": "func",
-      "format": "(...args: any[]) => any",
+      "format": "((...args: any[]) => any)",
       "name": "test7",
     },
     Object {
@@ -911,7 +911,7 @@ Object {
     },
     Object {
       "description": "func",
-      "format": "(...args: any[]) => any",
+      "format": "((...args: any[]) => any)",
       "name": "test7",
     },
     Object {

--- a/src/descToTypescript.js
+++ b/src/descToTypescript.js
@@ -40,7 +40,7 @@ const propTypeFormat = (propType) => {
         result = 'boolean';
         break;
       case 'func':
-        result = '(...args: any[]) => any';
+        result = '((...args: any[]) => any)';
         break;
       case 'node':
         result = 'React.ReactNode';


### PR DESCRIPTION
Generate valid TypeScript when `oneOf` is used and one of the possible values is a function. Resolves grommet/grommet#2538